### PR TITLE
Version 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,9 +3159,9 @@
       "dev": true
     },
     "dom-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-context/-/dom-context-1.0.0.tgz",
-      "integrity": "sha512-q51/ZIedIunPwiKmqd5rFbhQtlBWbEP3OfQ6VoLyMqOlvWlOjQA4SuV8Cwm0xGnT4Amm4mde1iUQhh0heYlReA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-context/-/dom-context-1.0.1.tgz",
+      "integrity": "sha512-hMNlGxoK61LpJglVm10FIAOy8P6YFAaROgn5XzW8zDTsCYyCk0GsH5VexiBEzrCnbSY7jz5vCWj9RQtgAHznHg=="
     },
     "dom-serializer": {
       "version": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1587,6 +1587,19 @@
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
       }
+    },
+    "@saasquatch/dom-context-hooks": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@saasquatch/dom-context-hooks/-/dom-context-hooks-0.1.0.tgz",
+      "integrity": "sha512-1jb5jQIlNay8mbhl0k4HHBevpmNeLGg92p5+8EBvjNuam9ToWfO3lj4PgYLolsYVGzsUDe+gMO3fx0A+egbs/A==",
+      "requires": {
+        "@saasquatch/universal-hooks": "^0.1.3"
+      }
+    },
+    "@saasquatch/universal-hooks": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@saasquatch/universal-hooks/-/universal-hooks-0.1.3.tgz",
+      "integrity": "sha512-3c7aAPHBbctvy0+V0p6NzZBUqVNBPpX0+bJAP4de2axfQrzXrE+7Fbo3WPjv7Hhs010igGb9EhgNXT+PqcECgg=="
     },
     "@sinonjs/commons": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stencil Component Starter",
   "source": "src/stencil-hooks.ts",
   "main": "build/stencil-hooks.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@stencil/core": "^1.17.4",
     "debug": "^4.3.1",
-    "dom-context": "^1.0.0",
+    "dom-context": "^1.0.1",
     "haunted": "^4.7.1"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "build"
   ],
+  "sideEffects": true,
   "scripts": {
     "build": "microbundle",
     "start": "stencil build --dev --watch --serve",
@@ -18,6 +19,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
+    "@saasquatch/dom-context-hooks": "^0.1.0",
     "@stencil/core": "^1.17.4",
     "debug": "^4.3.1",
     "dom-context": "^1.0.1",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,10 @@ export namespace Components {
     }
     interface EffectTest {
     }
+    interface InnocentChild {
+    }
+    interface KillerParent {
+    }
     interface MemoChild {
     }
     interface NullLifecycleTest {
@@ -49,6 +53,18 @@ declare global {
     var HTMLEffectTestElement: {
         prototype: HTMLEffectTestElement;
         new (): HTMLEffectTestElement;
+    };
+    interface HTMLInnocentChildElement extends Components.InnocentChild, HTMLStencilElement {
+    }
+    var HTMLInnocentChildElement: {
+        prototype: HTMLInnocentChildElement;
+        new (): HTMLInnocentChildElement;
+    };
+    interface HTMLKillerParentElement extends Components.KillerParent, HTMLStencilElement {
+    }
+    var HTMLKillerParentElement: {
+        prototype: HTMLKillerParentElement;
+        new (): HTMLKillerParentElement;
     };
     interface HTMLMemoChildElement extends Components.MemoChild, HTMLStencilElement {
     }
@@ -102,6 +118,8 @@ declare global {
         "callbacks-test": HTMLCallbacksTestElement;
         "domstate-child": HTMLDomstateChildElement;
         "effect-test": HTMLEffectTestElement;
+        "innocent-child": HTMLInnocentChildElement;
+        "killer-parent": HTMLKillerParentElement;
         "memo-child": HTMLMemoChildElement;
         "null-lifecycle-test": HTMLNullLifecycleTestElement;
         "reducer-child": HTMLReducerChildElement;
@@ -118,6 +136,10 @@ declare namespace LocalJSX {
     interface DomstateChild {
     }
     interface EffectTest {
+    }
+    interface InnocentChild {
+    }
+    interface KillerParent {
     }
     interface MemoChild {
     }
@@ -141,6 +163,8 @@ declare namespace LocalJSX {
         "callbacks-test": CallbacksTest;
         "domstate-child": DomstateChild;
         "effect-test": EffectTest;
+        "innocent-child": InnocentChild;
+        "killer-parent": KillerParent;
         "memo-child": MemoChild;
         "null-lifecycle-test": NullLifecycleTest;
         "reducer-child": ReducerChild;
@@ -158,6 +182,8 @@ declare module "@stencil/core" {
             "callbacks-test": LocalJSX.CallbacksTest & JSXBase.HTMLAttributes<HTMLCallbacksTestElement>;
             "domstate-child": LocalJSX.DomstateChild & JSXBase.HTMLAttributes<HTMLDomstateChildElement>;
             "effect-test": LocalJSX.EffectTest & JSXBase.HTMLAttributes<HTMLEffectTestElement>;
+            "innocent-child": LocalJSX.InnocentChild & JSXBase.HTMLAttributes<HTMLInnocentChildElement>;
+            "killer-parent": LocalJSX.KillerParent & JSXBase.HTMLAttributes<HTMLKillerParentElement>;
             "memo-child": LocalJSX.MemoChild & JSXBase.HTMLAttributes<HTMLMemoChildElement>;
             "null-lifecycle-test": LocalJSX.NullLifecycleTest & JSXBase.HTMLAttributes<HTMLNullLifecycleTestElement>;
             "reducer-child": LocalJSX.ReducerChild & JSXBase.HTMLAttributes<HTMLReducerChildElement>;

--- a/src/stencil-context.ts
+++ b/src/stencil-context.ts
@@ -119,10 +119,11 @@ export function useDomContext<T = unknown>(contextName: string, options: Polling
   }, [contextName, initialContextValue]);
 
   useEffect(() => {
+    listener.start();
     return () => {
       listener.stop();
     };
-  }, [listener]);
+  }, [listener, host.isConnected]);
 
   return state || initialContextValue.current;
 }
@@ -137,11 +138,13 @@ export function useDomContextState<T>(contextName: string, initialState?: T): re
   const host = useHost();
 
   const provider = useMemo(() => {
-    return new ContextProvider({
+    const p = new ContextProvider({
       contextName: contextName,
       element: host,
       initialState: initialState,
     });
+    p.start();
+    return p;
   }, [contextName, host]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description of the change

Fix bug in handling `connectedCallback` and `disconnectedCallback` gracefully. Those callbacks can be called multiple times.

Example: https://jsfiddle.net/dtnr5cu6/7/
Related Stack Overflow post: https://stackoverflow.com/questions/54874212/can-a-custom-elements-connectedcallback-be-called-more-than-once-before-disc

Implemented fix by reverting to the simple `update` and `teardown` flow from Haunted's component class: https://github.com/matthewp/haunted/blob/master/src/component.ts#L69

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
