### PR TITLE
update stencil version to support stencil ^3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2023-07-10
+
+### Updated
+
+- `@stencil/core` updated to support versions of Stencil >= 3.0.0
+
 ## [2.0.3] - 2023-04-20
 
 ### Changed
+
 - Updated license copyright to be in line with SaaSquatch open-source policy.
 
 ## [2.0.2] - 2021-08-23
@@ -52,7 +59,8 @@ No release notes.
 
 No release notes.
 
-[unreleased]: https://github.com/saasquatch/stencil-hooks/compare/@saasquatch%2Fstencil-hooks@2.0.3...HEAD
+[unreleased]: https://github.com/saasquatch/stencil-hooks/compare/@saasquatch%2Fstencil-hooks@3.0.0...HEAD
+[3.0.0]: https://github.com/saasquatch/stencil-hooks/releases/tag/%40saasquatch%2Fstencil-hooks%403.0.0
 [2.0.3]: https://github.com/saasquatch/stencil-hooks/releases/tag/%40saasquatch%2Fstencil-hooks%402.0.3
 [2.0.2]: https://github.com/saasquatch/stencil-hooks/releases/tag/%40saasquatch%2Fstencil-hooks%402.0.2
 [2.0.0]: https://github.com/saasquatch/stencil-hooks/releases/tag/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - `@stencil/core` updated to support versions of Stencil >= 3.0.0
+
 ## [2.0.4] - 2023-07-27
+### Updated
 
 - `@stencil/core` moved to devDependencies
 - peerDependencies added for @stencil/core < 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - 2023-07-10
+## [3.0.0] - 2023-07-27
 
 ### Updated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@saasquatch/dom-context-hooks": "^1.0.0",
-        "@stencil/core": "^2",
+        "@stencil/core": "^3.4.1",
         "debug": "^4.3.1",
         "dom-context": "^1.2.0",
         "haunted": "^4.7.1"
@@ -1912,25 +1912,6 @@
         "rollup": "^1.20.0 || ^2.0.0"
       }
     },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
-      "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.0.0",
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -1981,14 +1962,14 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
+      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=12.10.0",
+        "node": ">=14.10.0",
         "npm": ">=6.0.0"
       }
     },
@@ -4587,9 +4568,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -5330,7 +5311,7 @@
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
     },
     "node_modules/is-negative-zero": {
@@ -6798,6 +6779,25 @@
         "microbundle": "dist/cli.js"
       }
     },
+    "node_modules/microbundle/node_modules/@rollup/plugin-node-resolve": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
+      "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.0",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.11.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0"
+      }
+    },
     "node_modules/microbundle/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -6808,6 +6808,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/microbundle/node_modules/rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
       }
     },
     "node_modules/micromatch": {
@@ -9221,17 +9235,19 @@
       }
     },
     "node_modules/rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
-      },
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-bundle-size": {
@@ -12721,19 +12737,6 @@
         "@rollup/pluginutils": "^3.0.8"
       }
     },
-    "@rollup/plugin-node-resolve": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
-      "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.0",
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1"
-      }
-    },
     "@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -12778,9 +12781,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
+      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g=="
     },
     "@types/babel__core": {
       "version": "7.1.12",
@@ -14903,9 +14906,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -15479,7 +15482,7 @@
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
     },
     "is-negative-zero": {
@@ -16650,11 +16653,35 @@
         "typescript": "^3.9.5"
       },
       "dependencies": {
+        "@rollup/plugin-node-resolve": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
+          "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^3.0.0",
+            "@types/resolve": "0.0.8",
+            "builtin-modules": "^3.1.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.11.1"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
         }
       }
     },
@@ -18623,14 +18650,13 @@
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-bundle-size": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/stencil-hooks",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/stencil-hooks",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@saasquatch/dom-context-hooks": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,20 @@
       "license": "MIT",
       "dependencies": {
         "@saasquatch/dom-context-hooks": "^1.0.0",
-        "@stencil/core": "^3",
         "debug": "^4.3.1",
         "dom-context": "^1.2.0",
         "haunted": "^4.7.1"
       },
       "devDependencies": {
+        "@stencil/core": "^3",
         "@types/puppeteer": "2.0.1",
         "jest-cli": "26.0.1",
         "jest-cucumber": "^3.0.0",
         "microbundle": "^0.12.4",
         "puppeteer": "2.1.1"
+      },
+      "peerDependencies": {
+        "@stencil/core": ">= 3 < 4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1962,9 +1965,10 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.2.tgz",
+      "integrity": "sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==",
+      "dev": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -12781,9 +12785,10 @@
       }
     },
     "@stencil/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-7rjOmM0W9K5op2gtOQRLERGH1155rv2fm6ppxOzYqqG8ISct4m9skp5XgUBYPu+GSPsJFdRuCIQs0IuVsG/7+g=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.2.tgz",
+      "integrity": "sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@saasquatch/dom-context-hooks": "^1.0.0",
-        "@stencil/core": "^3.4.1",
+        "@stencil/core": "^3",
         "debug": "^4.3.1",
         "dom-context": "^1.2.0",
         "haunted": "^4.7.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@saasquatch/dom-context-hooks": "^1.0.0",
-    "@stencil/core": "^3.4.1",
+    "@stencil/core": "^3",
     "debug": "^4.3.1",
     "dom-context": "^1.2.0",
     "haunted": "^4.7.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@saasquatch/dom-context-hooks": "^1.0.0",
-    "@stencil/core": "^2",
+    "@stencil/core": "^3.4.1",
     "debug": "^4.3.1",
     "dom-context": "^1.2.0",
     "haunted": "^4.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-hooks",
-  "version": "3.0.0-1",
+  "version": "3.0.0",
   "description": "Stencil Component Starter",
   "source": "src/stencil-hooks.ts",
   "main": "build/stencil-hooks.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-hooks",
-  "version": "2.0.3",
+  "version": "3.0.0-1",
   "description": "Stencil Component Starter",
   "source": "src/stencil-hooks.ts",
   "main": "build/stencil-hooks.js",
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@saasquatch/dom-context-hooks": "^1.0.0",
-    "@stencil/core": "^3",
     "debug": "^4.3.1",
     "dom-context": "^1.2.0",
     "haunted": "^4.7.1"
@@ -28,10 +27,14 @@
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",
   "devDependencies": {
+    "@stencil/core": "^3",
     "@types/puppeteer": "2.0.1",
     "jest-cli": "26.0.1",
     "jest-cucumber": "^3.0.0",
     "microbundle": "^0.12.4",
     "puppeteer": "2.1.1"
+  },
+  "peerDependencies": {
+    "@stencil/core": ">= 3 < 4"
   }
 }


### PR DESCRIPTION
## Description of the change

> Upgrades version of @stencil/core to ^3
> Fixes issue where using `@stencil/core` higher than version 2 resulted in a number of duplicate identifier errors

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
